### PR TITLE
GithubActionsでGithubPagesにFlutterアプリをデプロイ

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -1,0 +1,30 @@
+name: gh_pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '12.x'
+      - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: '2.2.0'
+      - run: flutter pub get
+      - name: run build
+        run: flutter build web
+      - name: Deploy to GithubPages
+        uses: peaceiris/actions-gh-pages@v3
+        # if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/web
+          publish_branch: gh-pages

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -1,7 +1,6 @@
 name: gh_pages
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -23,7 +22,7 @@ jobs:
         run: flutter build web
       - name: Deploy to GithubPages
         uses: peaceiris/actions-gh-pages@v3
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/web

--- a/web/index.html
+++ b/web/index.html
@@ -11,8 +11,6 @@
     For more details:
     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
   -->
-  <base href="/">
-
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">


### PR DESCRIPTION
一旦デプロイ先をGithubPagesにしてみた。追加費用もなし。
GithubPagesへのデプロイには以下のActionを使うと便利。
https://github.com/peaceiris/actions-gh-pages